### PR TITLE
Modified i3exit shell script to work without root permission

### DIFF
--- a/i3exit
+++ b/i3exit
@@ -11,18 +11,18 @@ case "$1" in
         i3-msg exit
         ;;
     suspend)
-        gksu pm-suspend
+        lock && \
+        dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Suspend" boolean:true
         ;;
     hibernate)
-        lock && dbus-send --system --print-reply --dest="org.freedesktop.ConsoleKit" /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Hibernate
-        /sbin/reboot
+        lock && \
+        dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Hibernate" boolean:true
         ;;
     reboot)
-        dbus-send --system --print-reply --dest="org.freedesktop.ConsoleKit" /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Restart
+        dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
         ;;
     shutdown)
-        #dbus-send --system --print-reply --dest="org.freedesktop.ConsoleKit" /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop
-        /sbin/poweroff
+        dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.PowerOff" boolean:true
         ;;
     *)
         echo "Usage: $0 {lock|logout|suspend|hibernate|reboot|shutdown}"


### PR DESCRIPTION
Hi

I think you might like a version of `i3exit` that works without root permission. I tested the modified shell script on Ubuntu 14.04.4 LTS. It works fine for all cases except `hibernate` which I was not able to test as my system does not support hibernation.

Thanks for your work on the original `i3exit` script, it served me well.
